### PR TITLE
Webmock add and configure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,7 @@ group :development, :test do
   gem "rubocop-rspec", require: false
   gem "rubocop", require: false
 end
+
+group :test do
+  gem "webmock"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -77,6 +79,8 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.6.1)
       irb (>= 1.3.6)
@@ -93,6 +97,7 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -140,6 +145,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (5.0.0)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -223,6 +229,10 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -249,6 +259,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+
+RSpec.configure do |config|
+  config.before(:all) do
+    WebMock.disable_net_connect!(
+      allow_localhost: true,
+      net_http_connect_on_start: true
+    )
+  end
+end


### PR DESCRIPTION
Webmock is a basic testing tool which we will need.
 - this will reduce the size of the Planning application import commit down