### PR TITLE
FIX: If a property address is missing use planning app address

### DIFF
--- a/app/importers/planning_applications_importer.rb
+++ b/app/importers/planning_applications_importer.rb
@@ -65,7 +65,7 @@ class PlanningApplicationsImporter
      unless property
        property = Property.new(uprn: row[:uprn])
        property.build_address(
-                  full: row[:full],
+                  full: row[:full].blank? ? row[:address] : row[:full],
                   town: row[:town],
                   postcode: row[:postcode],
                   longitude: row[:map_east],


### PR DESCRIPTION
- When a property address is missing we use the planning application address instead.

- row[:address] in the abridged data from bucks came through as nil but checking for blank, even if more verbose, is more robust.

- adjusted another test that needed an exception to be thrown I was using full address being empty as a way to generate exception