### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -52,8 +52,9 @@ COPY Gemfile Gemfile.lock /app/
 
 # Install gems
 RUN bash -c "bundle install \
-    --without development test \
-    --deployment --no-cache && \
+    --local without 'development test' \
+    --local deployment 'true' \
+    --no-cache && \
     bundle clean --force"
 
 # Build image for npm dependencies
@@ -119,4 +120,8 @@ ARG RAILS_SERVE_STATIC_FILES=true
 ARG PORT=80
 ARG SECRET_KEY_BASE=notasecret
 
-RUN bash -c "bundle install --without development test --deployment --no-cache && bundle clean --force"
+RUN bash -c "bundle install \
+    --local without 'development test' \
+    --local deployment 'true' \
+    --no-cache && \
+    bundle clean --force"


### PR DESCRIPTION
### Description of change

* The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use
`bundle config set --local deployment 'true'`,
and stop using this flag.

* The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use
`bundle config set --local without 'development test'`, and stop using this flag.

This can be found under Deploy actions at `Build, tag, and push staging image to Amazon ECR`