### PR TITLE
Add option of using local file for data import

### DIFF
--- a/spec/importers/planning_application_importer_spec.rb
+++ b/spec/importers/planning_application_importer_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe "PlanningApplicationsImporter - PlanningApplication" do
     end
   end
 
+  context "when LOCAL_IMPORT_FILE env var is set to true" do
+    let(:planning_applications_importer) do
+      PlanningApplicationsImporter.new(local_authority_name: "Lambeth")
+    end
+
+    before do
+      create(:local_authority, name: "lambeth")
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("LOCAL_IMPORT_FILE").and_return("true")
+
+      allow(planning_applications_importer)
+        .to receive(:local_import_file)
+        .and_return(planning_applications_csv)
+    end
+
+    it "imports data from local file" do
+      expect { planning_applications_importer.call }
+        .to change(PlanningApplication, :count)
+        .by(1)
+    end
+  end
+
   def importer(local_authority_name: "lambeth")
     PlanningApplicationsImporter.new(local_authority_name: local_authority_name).call
   end


### PR DESCRIPTION
### Description of change

- In `PlanningApplicationsImporter`, if the env var `"USE_LOCAL_FILE"` is set to `true`, then use file in tmp directory instead of making request to s3.

### Story Link

https://trello.com/c/G92alEbC/1264-allow-use-of-local-planning-application-csv-in-development