### PR TITLE
Missing changing to use @hotwired/turbo-rails and not turbolinks

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,6 @@
     </div>
 
     <%= render "footer" %>
-    <%= javascript_include_tag "govuk", "data-turbolinks-track": "reload" %>
+    <%= javascript_include_tag "govuk", "data-turbo-track": "reload", defer: true %>
   </body>
 </html>


### PR DESCRIPTION
### Description of change

Missing changing to use @hotwired/turbo-rails and not turbolinks