### PR TITLE
Use Github Actions cache for docker directly

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -37,22 +37,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Setup docker cache
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: docker-cache
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
+      - name: Expose GitHub Runtime for Docker build
+        uses: crazy-max/ghaction-github-runtime@v2
 
-      - name: Load docker cache
-        run: |
-          if [ -d "docker-cache" ]; then
-            cat docker-cache/x* > paapi.tar
-            docker load < paapi.tar
-            rm -rf docker-cache
-          fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build, tag, and push ${{ inputs.environment-name }} image to Amazon ECR
         id: build-image
@@ -64,11 +53,12 @@ jobs:
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          DOCKER_BUILDKIT=1 docker build -t paapi:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production .
+          DOCKER_BUILDKIT=1 docker buildx build \
+            --cache-to type=gha,mode=max \
+            --cache-from type=gha \
+            --load \
+            -t paapi:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker save paapi:$IMAGE_TAG $(docker history -q paapi:$IMAGE_TAG | awk '!/<missing>/{print}') >paapi.tar
-          mkdir docker-cache
-          split -b 5G paapi.tar docker-cache/x
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >>$GITHUB_OUTPUT
 
       - name: Download task definition for db_migrate and strip unused properties


### PR DESCRIPTION
Faster and more reliable than exporting and importing (copied from BOPS)
